### PR TITLE
Fix: Detect and fail on missing go.sum dependencies

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35,6 +35,13 @@ async function run(dependencies = {}) {
 
     if (errorOutput) {
       core.warning(`govulncheck stderr: ${errorOutput}`);
+      
+      // Check for critical errors that indicate govulncheck couldn't run properly
+      if (errorOutput.includes('missing go.sum entry') || 
+          errorOutput.includes('could not import') ||
+          errorOutput.includes('invalid package name')) {
+        throw new Error(`govulncheck failed due to missing dependencies. Please run 'go mod tidy' to update go.mod and go.sum files.\n\nError: ${errorOutput}`);
+      }
     }
 
     // Log raw output for debugging

--- a/index.js
+++ b/index.js
@@ -29,6 +29,13 @@ async function run(dependencies = {}) {
 
     if (errorOutput) {
       core.warning(`govulncheck stderr: ${errorOutput}`);
+      
+      // Check for critical errors that indicate govulncheck couldn't run properly
+      if (errorOutput.includes('missing go.sum entry') || 
+          errorOutput.includes('could not import') ||
+          errorOutput.includes('invalid package name')) {
+        throw new Error(`govulncheck failed due to missing dependencies. Please run 'go mod tidy' to update go.mod and go.sum files.\n\nError: ${errorOutput}`);
+      }
     }
 
     // Log raw output for debugging

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -174,6 +174,34 @@ describe('GitHub Action Integration', () => {
     );
   });
 
+  it('should fail when go.sum is missing', async () => {
+    mockGovulncheck.run.mockResolvedValue({
+      output: '{"config": {}}',
+      errorOutput: 'missing go.sum entry for module providing package golang.org/x/net/html',
+      exitCode: 1
+    });
+
+    await expect(run({
+      govulncheck: mockGovulncheck,
+      parser: mockParser,
+      annotator: mockAnnotator
+    })).rejects.toThrow('govulncheck failed due to missing dependencies');
+  });
+
+  it('should fail when imports cannot be resolved', async () => {
+    mockGovulncheck.run.mockResolvedValue({
+      output: '{"config": {}}',
+      errorOutput: 'could not import golang.org/x/net/html (invalid package name: "")',
+      exitCode: 1
+    });
+
+    await expect(run({
+      govulncheck: mockGovulncheck,
+      parser: mockParser,
+      annotator: mockAnnotator
+    })).rejects.toThrow('govulncheck failed due to missing dependencies');
+  });
+
   it('should handle errors and set action as failed', async () => {
     const error = new Error('Failed to install govulncheck');
     mockGovulncheck.install.mockRejectedValue(error);


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where the action would incorrectly report "no vulnerabilities found" when govulncheck failed due to missing or outdated `go.sum` files.

## The Problem

When `go.sum` is missing or out of date, govulncheck fails with errors like:
```
missing go.sum entry for module providing package golang.org/x/net/html
could not import golang.org/x/net/html (invalid package name: "")
```

However, the action would continue processing and report "no vulnerabilities found" - which is misleading and dangerous since vulnerabilities could be present but weren't detected.

## The Solution

This PR adds error detection for these specific failure patterns in govulncheck's stderr output. When detected, the action now:

1. **Fails immediately** with a clear error message
2. **Instructs users** to run `go mod tidy` to fix the issue
3. **Prevents false negatives** by not claiming "no vulnerabilities" when analysis failed

## Changes

- Added error detection in `index.js` for three patterns:
  - `missing go.sum entry`
  - `could not import`
  - `invalid package name`
- Added tests to verify the behavior for both error cases
- Rebuilt `dist/index.js` with the changes

## Testing

Added two new test cases:
- ✅ Detects and fails when go.sum is missing
- ✅ Detects and fails when imports cannot be resolved

All existing tests continue to pass.

## Example Error Message

When the action detects missing dependencies, users will now see:
```
Error: govulncheck failed due to missing dependencies. Please run 'go mod tidy' to update go.mod and go.sum files.

Error: missing go.sum entry for module providing package golang.org/x/net/html...
```

## Impact

This is an important security fix that prevents the action from giving false confidence when dependency issues prevent vulnerability scanning.

🤖 Generated with [Claude Code](https://claude.ai/code)