### PR TITLE
Enable grouped updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Enable version updates for npm
   - package-ecosystem: "npm"
@@ -17,3 +21,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Configure Dependabot to batch updates by package ecosystem
- GitHub Actions updates will be grouped together
- npm dependencies will be grouped together

## Benefits
- Reduces PR noise by combining multiple dependency updates
- Single PR per ecosystem instead of individual PRs for each dependency
- Works seamlessly with the auto-merge workflow

## Test plan
- [ ] Dependabot configuration is valid
- [ ] Groups are properly configured for both ecosystems
- [ ] Next Dependabot run will create grouped PRs

🤖 Generated with [Claude Code](https://claude.ai/code)